### PR TITLE
removed aws access/secret keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,14 +55,15 @@ as Terraform will ask you to fill in the different values, but it is convenient.
 
 ```ini
 aws_account_id = "account-id"
-aws_access_key = "access-key"
-aws_secret_key = "secret-key"
 aws_region     = "eu-west-1"
 ```
 
 You are now ready to use Terraform!
 
-    $ terraform plan
+```bash
+$ terraform get
+$ terraform plan
+```
 
 If everything is OK, you can build the whole infrastructure:
 

--- a/providers.tf
+++ b/providers.tf
@@ -1,5 +1,4 @@
+variable "AWS_PROFILE" {}
 provider "aws" {
-  access_key = "${var.aws_access_key}"
-  secret_key = "${var.aws_secret_key}"
   region     = "${var.aws_region}"
 }

--- a/variables.tf
+++ b/variables.tf
@@ -1,16 +1,9 @@
 variable "aws_account_id" {
   description = "AWS account id"
-}
-
-variable "aws_access_key" {
-  description = "AWS access key"
-}
-
-variable "aws_secret_key" {
-  description = "AWS secret key"
+  default = "405322537961"
 }
 
 variable "aws_region" {
   description = "AWS region"
-  default     = "eu-west-1"
+  default     = "us-west-2"
 }


### PR DESCRIPTION
@TailorDev this is a great repo for getting started with Lambda and Terraform. I just noticed some unnecessary bits and removed them: the aws _**access/secret keys**_. 

If the AWS CLI is [setup properly], Terraform will pull these credentials out of the environment. At that point there is no need to have users (new to AWS/Terraform) put their credentials in a repo that has the potential to be committed.

[setup properly]:https://github.com/todd-dsm/mac-ops/wiki/Install-awscli