### PR TITLE
Removed need of passing aws_account_id variable

### DIFF
--- a/api_method/main.tf
+++ b/api_method/main.tf
@@ -23,8 +23,12 @@ variable "region" {
   description = "The AWS region, e.g., eu-west-1"
 }
 
-variable "account_id" {
-  description = "The AWS account ID"
+variable "lambda_arn" {
+  description = "The lambda arn to integrate"
+}
+
+variable "source_arn" {
+  description = "The gateway api execution arn to be passed to permission"
 }
 
 # Example: request for GET /hello
@@ -41,7 +45,7 @@ resource "aws_api_gateway_integration" "request_method_integration" {
   resource_id = "${var.resource_id}"
   http_method = "${aws_api_gateway_method.request_method.http_method}"
   type        = "AWS"
-  uri         = "arn:aws:apigateway:${var.region}:lambda:path/2015-03-31/functions/arn:aws:lambda:${var.region}:${var.account_id}:function:${var.lambda}/invocations"
+  uri         = "${var.lambda_arn}"
 
   # AWS lambdas can only be invoked with the POST method
   integration_http_method = "POST"
@@ -76,7 +80,7 @@ resource "aws_lambda_permission" "allow_api_gateway" {
   statement_id  = "AllowExecutionFromApiGateway"
   action        = "lambda:InvokeFunction"
   principal     = "apigateway.amazonaws.com"
-  source_arn    = "arn:aws:execute-api:${var.region}:${var.account_id}:${var.rest_api_id}/*/${var.method}${var.path}"
+  source_arn    = "${var.source_arn}/*/${var.method}${var.path}"
 }
 
 output "http_method" {

--- a/hello_lambda.tf
+++ b/hello_lambda.tf
@@ -61,7 +61,8 @@ module "hello_get" {
   path        = "${aws_api_gateway_resource.hello_api_res_hello.path}"
   lambda      = "${module.lambda.name}"
   region      = "${var.aws_region}"
-  account_id  = "${var.aws_account_id}"
+  lambda_arn  = "${module.lambda.arn}"
+  source_arn  = "${aws_api_gateway_rest_api.hello_api.execution_arn}"
 }
 
 # This is the code for method POST /hello, that will talk to the second lambda
@@ -73,7 +74,8 @@ module "hello_post" {
   path        = "${aws_api_gateway_resource.hello_api_res_hello.path}"
   lambda      = "${module.lambda_post.name}"
   region      = "${var.aws_region}"
-  account_id  = "${var.aws_account_id}"
+  lambda_arn  = "${module.lambda_post.arn}"
+  source_arn  = "${aws_api_gateway_rest_api.hello_api.execution_arn}"
 }
 
 # We can deploy the API now! (i.e. make it publicly available)

--- a/lambda/main.tf
+++ b/lambda/main.tf
@@ -27,3 +27,7 @@ resource "aws_lambda_function" "lambda" {
 output "name" {
   value = "${aws_lambda_function.lambda.function_name}"
 }
+
+output "arn" {
+  value = "${aws_lambda_function.lambda.invoke_arn}"
+}

--- a/variables.tf
+++ b/variables.tf
@@ -1,7 +1,3 @@
-variable "aws_account_id" {
-  description = "AWS account id"
-}
-
 variable "aws_access_key" {
   description = "AWS access key"
 }


### PR DESCRIPTION
One of the variables required on `variables.tf` is the AWS account ID. However, if we map correctly the resources on terraform config, it won't be needed. Instead of passing account ID to build arn, we can simply pass the arn itself.

If combined with PR #1, user will have to only provide region, which is much simpler.